### PR TITLE
change Dockerfile for get-pip.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo ". /opt/ros/kinetic/setup.bash" >> ~/.bashrc
-RUN cd /tmp && wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py
+RUN cd /tmp && wget https://bootstrap.pypa.io/3.5/get-pip.py && python get-pip.py
 RUN pip install pipenv
 
 COPY Pipfile* /app/


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other
## Description

- Modify Dockerfile because the syntax of [get-pip.py](https://bootstrap.pypa.io/get-pip.py) is python3.6 or later.
- Change [get-pip.py](https://bootstrap.pypa.io/3.5/get-pip.py) to use python3.5.